### PR TITLE
fix(backup): Increase memory for backup function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,7 @@ resource "google_cloud_run_service_iam_binding" "filestore_backup_scheduler_invo
 resource "google_project_iam_binding" "filestore_backup_runner_file_editor" {
   count = var.enable_auto_backup ? 1 : 0
 
-  project = data.google_client_config.current[0].project
+  project = data.google_client_config.current.project
 
   role = "roles/file.editor"
 
@@ -151,7 +151,7 @@ resource "google_cloudfunctions2_function" "backup" {
 
   service_config {
     max_instance_count    = 1
-    available_memory      = "256Mi"
+    available_memory      = var.auto_backup_function_mem
     timeout_seconds       = 60
     service_account_email = google_service_account.filestore_backup_runner[0].email
 

--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,7 @@ resource "google_cloud_run_service_iam_binding" "filestore_backup_scheduler_invo
 resource "google_project_iam_binding" "filestore_backup_runner_file_editor" {
   count = var.enable_auto_backup ? 1 : 0
 
-  project = data.google_client_config.current.project
+  project = data.google_client_config.current[0].project
 
   role = "roles/file.editor"
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,12 @@ variable "auto_backup_function_location" {
   default     = null
 }
 
+variable "auto_backup_function_mem" {
+  description = "Memory to allocate to the backup function"
+  type        = string
+  default     = "512Mi"
+}
+
 variable "auto_backup_function_storage_bucket_name" {
   description = "Google Cloud Run Function source bucket name for Filestore instance auto backup."
   type        = string


### PR DESCRIPTION
Took me ages to figure out what the hell was going on for this.
But basically the auto backup function runner was running out of memory and was being cancelled.

Here are the logs, you can see that the original requests with `256Mi` memory are being cancelled while the later request with `512Mi` is working as expected.
<img width="1649" height="905" alt="image" src="https://github.com/user-attachments/assets/a67c3fec-6892-40fe-96d3-22f18e397f44" />

i figured since we may need to adjust this in the future it might be prudent to parameterise this.. 
