### PR TITLE
feat(backups): add basic backup retention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ Check out comprehensive examples in [`tests`](./tests) folder.
 
 ![Filestore Auto Backup](https://raw.githubusercontent.com/Tensho/terraform-google-filestore/refs/heads/main/filestore-auto-backup.png)
 
-> [!WARNING]
-> This module doesn't implement backups cleanup.
-> The easiest way to implement it at storage level with [Google Cloud Storage Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle) feature.
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Check out comprehensive examples in [`tests`](./tests) folder.
 
 ![Filestore Auto Backup](https://raw.githubusercontent.com/Tensho/terraform-google-filestore/refs/heads/main/filestore-auto-backup.png)
 
+> [!NOTE]
+> Backup retention/deletion is included as part of the automatic backup script (Cloud Function).
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/backup/main.py
+++ b/backup/main.py
@@ -72,13 +72,9 @@ def cleanup_old_backups(request, number_to_keep):
             delete_url = f"https://file.googleapis.com/v1/{backup['name']}"
             logger.info(f"Deleting backup: {backup['name']}")
             r = session.delete(url=delete_url, headers=headers)
-            if r.status_code == requests.codes.ok:
-                logger.info(f"Backup '{backup['name']}' deleted successfully.")
-            else:
-                logger.error(f"Failed to delete backup '{backup['name']}': {r.text}")
-                r.raise_for_status()
+            r.raise_for_status()
     except Exception as e:
-        logger.exception("Error during backup cleanup.")
+        logger.exception(f"Error during backup cleanup: {e}")
         raise
 
 def create_backup(request):
@@ -98,19 +94,17 @@ def create_backup(request):
         logger.info(f"Triggering backup creation: {backup_id}")
         r = session.post(url=trigger_run_url, headers=headers, data=json.dumps(post_data))
         if r.status_code == requests.codes.ok:
-            logger.info("Backup successfully initiated.")
-        else:
-            logger.error(f"Backup creation failed: {r.text}")
-            r.raise_for_status()
+        logger.info("Backup successfully initiated.")
+        r.raise_for_status()
     except Exception as e:
-        logger.exception("Error while creating backup.")
+        logger.exception(f"Error while creating backup: {e}")
         raise
 
     if BACKUP_RETENTION > 0: # Retain all backups if set to 0
         try:
             logger.info(f"Cleaning up old backups. Retaining latest {BACKUP_RETENTION}.")
             cleanup_old_backups(request, BACKUP_RETENTION)
-            return json.dumps({"status": "Backup started. Cleanup complete."})
+            return json.dumps({"status": "Backup started. Cleanup started."})
         except Exception as e:
             logger.warning("Backup started, but cleanup failed.")
             return json.dumps({"status": "Backup started. Cleanup failed.", "error": str(e)})

--- a/backup/main.py
+++ b/backup/main.py
@@ -1,4 +1,4 @@
-import google.auth.default
+import google.auth
 import google.auth.transport.requests as google_auth_requests 
 import time
 import requests

--- a/backup/main.py
+++ b/backup/main.py
@@ -82,7 +82,7 @@ def create_backup(request):
     The main CloudFunction entrypoint. 
     """
     backup_id = get_backup_id()
-    trigger_run_url = f"https://file.googleapis.com/v1/projects/{PROJECT_ID}/locations/{BACKUP_REGION}/backups?backupId={backup_id}"
+    backups_url = f"https://file.googleapis.com/v1/projects/{PROJECT_ID}/locations/{BACKUP_REGION}/backups?backupId={backup_id}"
     headers = {'Content-Type': 'application/json'}
     post_data = {
         "description": "Filestore auto backup managed by Cloud Run Function",

--- a/backup/main.py
+++ b/backup/main.py
@@ -1,4 +1,4 @@
-import google.auth
+import google.auth.default
 import google.auth.transport.requests as google_auth_requests 
 import time
 import requests

--- a/backup/main.py
+++ b/backup/main.py
@@ -1,41 +1,120 @@
 import google.auth
 import google.auth.transport.requests
-from google.auth.transport.requests import AuthorizedSession
 import time
 import requests
 import json
 import os
+import logging
+from datetime import datetime
+from google.auth.transport.requests import AuthorizedSession
+from google.cloud import logging as cloud_logging
+
+
+# Setup logging 
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+numeric_level = getattr(logging, LOG_LEVEL, logging.INFO)
+cloud_logging_client = cloud_logging.Client()
+cloud_logging_client.setup_logging(log_level=numeric_level)
+logger = logging.getLogger(__name__)
 
 PROJECT_ID = os.environ.get("PROJECT_ID")
 INSTANCE_LOCATION = os.environ.get("INSTANCE_LOCATION")
 INSTANCE_NAME = os.environ.get("INSTANCE_NAME")
 INSTANCE_FILE_SHARE_NAME = os.environ.get("INSTANCE_FILE_SHARE_NAME")
 BACKUP_REGION = os.environ.get("BACKUP_REGION")
+BACKUP_RETENTION = int(os.environ.get("BACKUP_RETENTION", 0))
 
-credentials, project = google.auth.default()
-request = google.auth.transport.requests.Request()
-credentials.refresh(request)
-authed_session = AuthorizedSession(credentials)
+try:
+    credentials, project = google.auth.default()
+    request = google.auth.transport.requests.Request()
+    credentials.refresh(request)
+    authed_session = AuthorizedSession(credentials)
+except Exception as e:
+    logger.exception("Failed to authenticate with Google Cloud.")
+    raise
 
 def get_backup_id():
     return INSTANCE_NAME + '-' + time.strftime("%Y%m%d-%H%M%S")
 
+def parse_truncated_iso(iso_str):
+    iso_str = iso_str.rstrip('Z')
+    if '.' in iso_str:
+        date_part, frac = iso_str.split('.')
+        frac = frac[:6]
+        iso_str = f"{date_part}.{frac}"
+    return datetime.fromisoformat(iso_str)
+
+def cleanup_old_backups(request, number_to_keep):
+    """
+    Sort backups based on data and retain most recent `number_to_keep` backups. Discard the rest.
+    """
+
+    backups_url = f"https://file.googleapis.com/v1/projects/{PROJECT_ID}/locations/{BACKUP_REGION}/backups"
+    headers = {'Content-Type': 'application/json'}
+
+    try:
+        logger.info(f"Fetching backups from {backups_url}")
+        r = authed_session.get(url=backups_url, headers=headers)
+        r.raise_for_status()
+        data = r.json()
+        backups = data.get("backups", [])
+        logger.info(f"Found {len(backups)} backups.")
+    except Exception as e:
+        logger.exception("Error fetching backup list.")
+        raise
+
+    try:
+        sorted_backups = sorted(
+            [{'name': b['name'], 'createTime': b['createTime']} for b in backups],
+            key=lambda x: parse_truncated_iso(x['createTime']),
+            reverse=True
+        )
+
+        for backup in sorted_backups[number_to_keep:]:
+            delete_url = f"https://file.googleapis.com/v1/{backup['name']}"
+            logger.info(f"Deleting backup: {backup['name']}")
+            r = authed_session.delete(url=delete_url, headers=headers)
+            if r.status_code == requests.codes.ok:
+                logger.info(f"Backup '{backup['name']}' deleted successfully.")
+            else:
+                logger.error(f"Failed to delete backup '{backup['name']}': {r.text}")
+                r.raise_for_status()
+    except Exception as e:
+        logger.exception("Error during backup cleanup.")
+        raise
+
 def create_backup(request):
-    trigger_run_url = "https://file.googleapis.com/v1/projects/{}/locations/{}/backups?backupId={}".format(PROJECT_ID, BACKUP_REGION, get_backup_id())
-    headers = {
-      'Content-Type': 'application/json'
-    }
+    """
+    The main CloudFunction entrypoint. 
+    """
+    backup_id = get_backup_id()
+    trigger_run_url = f"https://file.googleapis.com/v1/projects/{PROJECT_ID}/locations/{BACKUP_REGION}/backups?backupId={backup_id}"
+    headers = {'Content-Type': 'application/json'}
     post_data = {
-      "description": "Filestore auto backup managed by Cloud Run Function",
-      "source_instance": "projects/{}/locations/{}/instances/{}".format(PROJECT_ID, INSTANCE_LOCATION, INSTANCE_NAME),
-      "source_file_share": "{}".format(INSTANCE_FILE_SHARE_NAME)
+        "description": "Filestore auto backup managed by Cloud Run Function",
+        "source_instance": f"projects/{PROJECT_ID}/locations/{INSTANCE_LOCATION}/instances/{INSTANCE_NAME}",
+        "source_file_share": INSTANCE_FILE_SHARE_NAME
     }
-    print("Making a request to " + trigger_run_url)
-    r = authed_session.post(url=trigger_run_url, headers=headers, data=json.dumps(post_data))
-    data = r.json()
-    print(data)
-    if r.status_code == requests.codes.ok:
-      print(str(r.status_code) + ": The backup is uploading in the background.")
-    else:
-      raise RuntimeError(data['error'])
+
+    try:
+        logger.info(f"Triggering backup creation: {backup_id}")
+        r = authed_session.post(url=trigger_run_url, headers=headers, data=json.dumps(post_data))
+        if r.status_code == requests.codes.ok:
+            logger.info("Backup successfully initiated.")
+        else:
+            logger.error(f"Backup creation failed: {r.text}")
+            r.raise_for_status()
+    except Exception as e:
+        logger.exception("Error while creating backup.")
+        raise
+
+    if BACKUP_RETENTION > 0: # Retain all backups if set to 0
+        try:
+            logger.info(f"Cleaning up old backups. Retaining latest {BACKUP_RETENTION}.")
+            cleanup_old_backups(request, BACKUP_RETENTION)
+            return json.dumps({"status": "Backup started. Cleanup complete."})
+        except Exception as e:
+            logger.warning("Backup started, but cleanup failed.")
+            return json.dumps({"status": "Backup started. Cleanup failed.", "error": str(e)})
+
     return "Backup creation has begun!"

--- a/backup/main.py
+++ b/backup/main.py
@@ -1,12 +1,10 @@
 import google.auth
-import google.auth.transport.requests as google_auth_requests 
 import time
 import requests
 import json
 import os
 import logging
 from datetime import datetime
-# from google.auth.transport.requests import AuthorizedSession
 from google.cloud import logging as cloud_logging
 
 
@@ -26,9 +24,9 @@ BACKUP_RETENTION = int(os.environ.get("BACKUP_RETENTION", 0))
 
 try:
     credentials, project = google.auth.default()
-    request = google_auth_requests.Request()
+    request = google.auth.transport.requests.Request()
     credentials.refresh(request)
-    session = google_auth_requests.AuthorizedSession(credentials)
+    session = google.auth.transport.requests.AuthorizedSession(credentials)
 except Exception as e:
     logger.exception("Failed to authenticate with Google Cloud.")
     raise

--- a/backup/main.py
+++ b/backup/main.py
@@ -93,7 +93,6 @@ def create_backup(request):
     try:
         logger.info(f"Triggering backup creation: {backup_id}")
         r = session.post(url=trigger_run_url, headers=headers, data=json.dumps(post_data))
-        if r.status_code == requests.codes.ok:
         logger.info("Backup successfully initiated.")
         r.raise_for_status()
     except Exception as e:

--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -1,3 +1,4 @@
 functions-framework==3.*
 google-auth==2.29.0
 requests==2.31.0
+google-cloud-logging>=3.4.0

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "auto_backup_function_storage_bucket_name" {
   type        = string
   default     = null
 }
+
+variable "auto_backup_retention" {
+  description = "Total number of backups to keep. Setting 0 keeps all"
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
This adds a basic backup retention policy to the Cloud Function.

Rather than adding it as a separate function/scheduled task I decided to include it in the current function.  I figured this is already on a schedule so it makes sense for it to clean up after itself during runtime..

This change adds 2 more environment variables
1. `LOG_LEVEL` - Which can be used to adjust the verbosity of the logging
2. `BACKUP_RETENTION` - Which can be used to keep N number of recent backups.  If N=0 no backups will be deleted.

Unfortunately I could not find a clean way to modify the `filestore_backup_runner_file_editor` IAM binding's condition expression to allow access to `file.backups.create` and `file.backups.list` within the same expression.  Therefore I added an extra iam member resource (`filestore_backup_runner_list`) which takes care of listing the current backups.
I do not think `file.backups.list` supports conditional IAM

I have also taken the liberty to refactor the `python` code to help with logging and exception handling (hope that is ok!).
I also added `google-cloud-logging` which logs to GCP's logging system in a nice way :)


## Testing

I have been triggering this by forcibly running the scheduled job
<img width="1637" height="604" alt="image" src="https://github.com/user-attachments/assets/5d704b42-fbd0-4425-be28-2f4ccf6f5b59" />

I set `auto_backup_retention = 3`

The Cloud Run logs show that the backup is triggered and created and also that a backup that falls outside the retention policy is detected and subsequently removed
<img width="1738" height="913" alt="image" src="https://github.com/user-attachments/assets/85306485-1181-4718-9efb-af47228c6885" />



Here are the listed backups, 3 as expected.
<img width="1682" height="528" alt="image" src="https://github.com/user-attachments/assets/a5b3584a-62d2-4678-9430-09ac7bfdc9f4" />

If `auto_backup_retention` is increased to `5` and run the job a few more times....
<img width="1679" height="690" alt="image" src="https://github.com/user-attachments/assets/e1e7a352-eeb2-4989-850b-d6d097e669bc" />

And finally if we return to `auto_backup_retention = 3`, we see that the script creates a new backup and then removes the oldest 3, leaving 3 in total.
<img width="1706" height="946" alt="image" src="https://github.com/user-attachments/assets/1dc53528-e88c-4d47-b81e-79c3e04e8cda" />

<img width="1460" height="499" alt="image" src="https://github.com/user-attachments/assets/17402a63-ac89-43de-9eb9-c17629b90266" />

Cheers! :beers: 




 


