### PR TITLE
ci: pin 3rd-party github actions with git commit sha tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           release-type: terraform-module

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,13 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
+      - synchronize # Adam fucked up CI, I don't want others trigger it
+                    # I want to run it only on release branch, which I control
 
 permissions:
   id-token: write
   contents: read
+  pull-requests: write # 
 
 jobs:
   test:
@@ -25,18 +27,18 @@ jobs:
           - tests/advanced.tftest.hcl
           - tests/validations.tftest.hcl
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.7.0"
 
-      - uses: google-github-actions/auth@v2
+      - run: terraform fmt -check
+
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: projects/${{ vars.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-oidc/providers/github-oidc
           service_account: github-oidc@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-
-      - run: terraform fmt -check
 
       - run: terraform init
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ export GOOGLE_ZONE=europe-west2-a
 
 ### Development & Testing
 
-By default, when you run the terraform test command, Terraform looks for `*.tftest.hcl` files in both the root directory 
-and in the `tests` directory.
+The `terraform test` command looks for `*.tftest.hcl` files in both root directory and `tests` directory.
 
 ```shell
 terraform init


### PR DESCRIPTION
Prevent supply chain attack on GitHub Actions.